### PR TITLE
Fix constant name typo

### DIFF
--- a/classes/i18n/AppLocale.inc.php
+++ b/classes/i18n/AppLocale.inc.php
@@ -181,7 +181,7 @@ class AppLocale extends PKPLocale {
 			LOCALE_COMPONENT_APP_ADMIN => $baseDir . 'admin.po',
 			LOCALE_COMPONENT_APP_DEFAULT => $baseDir . 'default.po',
 			LOCALE_COMPONENT_APP_API => $baseDir . 'api.po',
-			LOCALE_COMPONENT_APP_EMAILS => $baseDir . 'emails.po',
+			LOCALE_COMPONENT_APP_EMAIL => $baseDir . 'emails.po',
 		);
 	}
 }


### PR DESCRIPTION
Sorry, @ajnyga, there was a typo in https://github.com/ajnyga/ojs/commit/9d78502ba6a75f0474973c086efdc80df8910441...